### PR TITLE
refactor: Map state read bytecode ahead of execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,7 @@ dependencies = [
 [[package]]
 name = "essential-asm-gen"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#591ec4b2db5bc0c9e3ad9083c51d9ea43a1c8d4f"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#83afe62e56b8a7b20ad546f0fc38868d1027a2ab"
 dependencies = [
  "essential-asm-spec",
  "essential-types",
@@ -518,7 +518,7 @@ dependencies = [
 [[package]]
 name = "essential-asm-spec"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#591ec4b2db5bc0c9e3ad9083c51d9ea43a1c8d4f"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#83afe62e56b8a7b20ad546f0fc38868d1027a2ab"
 dependencies = [
  "serde",
  "serde_yaml",
@@ -527,7 +527,7 @@ dependencies = [
 [[package]]
 name = "essential-constraint-asm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#591ec4b2db5bc0c9e3ad9083c51d9ea43a1c8d4f"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#83afe62e56b8a7b20ad546f0fc38868d1027a2ab"
 dependencies = [
  "essential-asm-gen",
  "essential-types",
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "essential-constraint-vm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#591ec4b2db5bc0c9e3ad9083c51d9ea43a1c8d4f"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#83afe62e56b8a7b20ad546f0fc38868d1027a2ab"
 dependencies = [
  "ed25519-dalek",
  "essential-constraint-asm",
@@ -591,7 +591,7 @@ dependencies = [
 [[package]]
 name = "essential-state-asm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#591ec4b2db5bc0c9e3ad9083c51d9ea43a1c8d4f"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#83afe62e56b8a7b20ad546f0fc38868d1027a2ab"
 dependencies = [
  "essential-asm-gen",
  "essential-constraint-asm",
@@ -601,7 +601,7 @@ dependencies = [
 [[package]]
 name = "essential-state-read-vm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#591ec4b2db5bc0c9e3ad9083c51d9ea43a1c8d4f"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#83afe62e56b8a7b20ad546f0fc38868d1027a2ab"
 dependencies = [
  "essential-constraint-vm",
  "essential-state-asm",
@@ -612,7 +612,7 @@ dependencies = [
 [[package]]
 name = "essential-types"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#591ec4b2db5bc0c9e3ad9083c51d9ea43a1c8d4f"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#83afe62e56b8a7b20ad546f0fc38868d1027a2ab"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
This avoids building the operation mapping twice in favour of mapping ahead of execution and sharing the mapping between both pre and post state slot reads.

Also updates the `essential-base` crates to make use of the new support for mapping over an existing bytecode slice.

Note that this does slightly change up the performance trade-offs, e.g. in the case that a state read contains a lot of bytecode but execution would fail immediately, this new approach may be more costly.

However, the same could be said for the inverse, e.g. if the state read does a lot of heavy compute but the end of the bytecode contains an invalid operation, this change would avoid doing any unnecessary execution in the first place. I think this change is worth it, as mapping the bytecode is predictably much faster than execution.