### PR TITLE
feat: add solution-outcome, check-solution, check-solution-with-data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 result
 /target
+.DS_Store

--- a/crates/essential/src/solution.rs
+++ b/crates/essential/src/solution.rs
@@ -14,6 +14,7 @@ use storage::{StateStorage, Storage};
 use tokio::task::JoinSet;
 use transaction_storage::TransactionStorage;
 
+pub use validate::validate_solution_with_data;
 pub use validate::validate_solution_with_deps;
 
 pub(crate) mod read;

--- a/crates/essential/src/solution/read.rs
+++ b/crates/essential/src/solution/read.rs
@@ -31,15 +31,15 @@ where
 pub async fn read_partial_solutions_from_storage<S>(
     solution: &Solution,
     storage: &S,
-) -> anyhow::Result<HashMap<ContentAddress, PartialSolution>>
+) -> anyhow::Result<HashMap<ContentAddress, Arc<PartialSolution>>>
 where
     S: Storage,
 {
-    let mut partial_solutions: HashMap<ContentAddress, PartialSolution> = HashMap::new();
+    let mut partial_solutions: HashMap<_, _> = HashMap::new();
     for ps_address in &solution.partial_solutions {
         if let Ok(Some(ps)) = storage.get_partial_solution(&ps_address.data).await {
             ensure!(verify(&ps));
-            partial_solutions.insert(ps_address.data.clone(), ps.data);
+            partial_solutions.insert(ps_address.data.clone(), Arc::new(ps.data));
         } else {
             anyhow::bail!("Failed to retrieve partial solution from storage");
         }

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -100,3 +100,58 @@ Returns: `Vec<Block>` as JSON
 ```bash
 curl -X GET -H "Content-Type: application/json" "http://localhost:59498/list-winning-blocks?start=0&end=1&page=0"
 ```
+### GET `/solution-outcome/:hash`
+Parameters: 
+- `:hash` = `[u8; 32]` as base64 string. This is the hash of the solution.
+
+Returns: `Option<SolutionOutcome>` as JSON
+```rust
+pub enum SolutionOutcome {
+    Success(u64),
+    Fail(String),
+}
+```
+
+**Example:**
+```bash
+curl -X GET -H "Content-Type: application/json" "http://localhost:59498/solution-outcome/NsFZ12tS4D5JY2NgfFlAIn9i9OBI3zRLBQFZvJe7o9c="
+```
+### Post `/check-solution`
+Check a solution against deployed intents without changing state.\
+This is a dry run of the solution.\
+Body: `Signed<Solution>` as JSON \
+Returns: `CheckSolutionOutput` as JSON
+```rust
+pub struct CheckSolutionOutput {
+    pub utility: f64,
+    pub gas: u64,
+}
+```
+
+**Example:**
+```bash
+curl -X POST -H "Content-Type: application/json" -d '{"data":{"data":[],"state_mutations":[],"partial_solutions":[]},"signature":[[]]}' http://localhost:59498/check-solution
+```
+### Post `/check-solution-with-data`
+Check a solution with all partial solutions and intents without changing state.\
+This is a dry run of the solution.\
+Body: `CheckSolution` as JSON \
+```rust
+struct CheckSolution {
+    solution: Signed<Solution>,
+    partial_solutions: Vec<PartialSolution>,
+    intents: Vec<Intent>,
+}
+```
+Returns: `CheckSolutionOutput` as JSON
+```rust
+pub struct CheckSolutionOutput {
+    pub utility: f64,
+    pub gas: u64,
+}
+```
+
+**Example:**
+```bash
+curl -X POST -H "Content-Type: application/json" -d '{"solution": {"data":{"data":[],"state_mutations":[],"partial_solutions":[]},"signature":[[]]}, "partial_solutions: [], intents: [{"slots":{"decision_variables":0,"state":[]},"state_read":[],"constraints":[],"directive":"Satisfy"}]}' http://localhost:59498/check-solution-with-data
+```


### PR DESCRIPTION
Adds three new api calls that were missing.
This enables checking:
- The outcome of a submitted solution.
- Dry running a solution against deployed solutions.
- Dry running a solution with all required data.