### PR TITLE
feat: Update rest-server to match essential-base address/hash encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "essential-asm-gen"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#dcd7ca9368338f3ab2adb928c922ecf8e7883a61"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#c928b6f60fd07d23d2db8b88251220569e68ce58"
 dependencies = [
  "essential-asm-spec",
  "essential-types",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "essential-asm-spec"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#dcd7ca9368338f3ab2adb928c922ecf8e7883a61"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#c928b6f60fd07d23d2db8b88251220569e68ce58"
 dependencies = [
  "serde",
  "serde_yaml",
@@ -543,14 +543,13 @@ dependencies = [
 [[package]]
 name = "essential-check"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#dcd7ca9368338f3ab2adb928c922ecf8e7883a61"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#c928b6f60fd07d23d2db8b88251220569e68ce58"
 dependencies = [
  "essential-constraint-vm",
  "essential-hash",
  "essential-sign",
  "essential-state-read-vm",
  "essential-types",
- "hex",
  "rayon",
  "thiserror",
  "tokio",
@@ -560,7 +559,7 @@ dependencies = [
 [[package]]
 name = "essential-constraint-asm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#dcd7ca9368338f3ab2adb928c922ecf8e7883a61"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#c928b6f60fd07d23d2db8b88251220569e68ce58"
 dependencies = [
  "essential-asm-gen",
  "essential-types",
@@ -570,7 +569,7 @@ dependencies = [
 [[package]]
 name = "essential-constraint-vm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#dcd7ca9368338f3ab2adb928c922ecf8e7883a61"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#c928b6f60fd07d23d2db8b88251220569e68ce58"
 dependencies = [
  "ed25519-dalek",
  "essential-constraint-asm",
@@ -585,7 +584,7 @@ dependencies = [
 [[package]]
 name = "essential-hash"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#dcd7ca9368338f3ab2adb928c922ecf8e7883a61"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#c928b6f60fd07d23d2db8b88251220569e68ce58"
 dependencies = [
  "essential-types",
  "postcard",
@@ -683,7 +682,7 @@ dependencies = [
 [[package]]
 name = "essential-sign"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#dcd7ca9368338f3ab2adb928c922ecf8e7883a61"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#c928b6f60fd07d23d2db8b88251220569e68ce58"
 dependencies = [
  "essential-hash",
  "essential-types",
@@ -694,7 +693,7 @@ dependencies = [
 [[package]]
 name = "essential-state-asm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#dcd7ca9368338f3ab2adb928c922ecf8e7883a61"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#c928b6f60fd07d23d2db8b88251220569e68ce58"
 dependencies = [
  "essential-asm-gen",
  "essential-constraint-asm",
@@ -704,7 +703,7 @@ dependencies = [
 [[package]]
 name = "essential-state-read-vm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#dcd7ca9368338f3ab2adb928c922ecf8e7883a61"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#c928b6f60fd07d23d2db8b88251220569e68ce58"
 dependencies = [
  "essential-constraint-vm",
  "essential-state-asm",
@@ -742,8 +741,10 @@ dependencies = [
 [[package]]
 name = "essential-types"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#dcd7ca9368338f3ab2adb928c922ecf8e7883a61"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#c928b6f60fd07d23d2db8b88251220569e68ce58"
 dependencies = [
+ "base64",
+ "hex",
  "serde",
 ]
 
@@ -994,6 +995,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hex-conservative"


### PR DESCRIPTION
Based on essential-contributions/essential-base#118.

This only updates the encoding used throughout the public-facing `rest-server`. It does not touch any of the rqlite-storage encoding.

Edit: I noticed this has a couple conflicts with #111 - happy to wait for that to land first.

To-Do
-----

- [x] Switch back to `main` branch after upstream PR has landed.