### PR TITLE
feat: add publish gh action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,28 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - run: cargo install --version "0.1.1" cargo-toml-lint
     - run: git ls-files | grep Cargo.toml$ | xargs --verbose -n 1 cargo-toml-lint
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: 
+      [
+        nix,
+        nix-fmt-check,
+        cargo,
+        cargo-toml-lint,
+      ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@v10
+      - uses: DeterminateSystems/magic-nix-cache-action@v4
+      - run: nix develop
+      - uses: katyo/publish-crates@v2
+        id: publish-crates
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          dry-run: true
+      - name: if my-crate published
+        if: fromJSON(steps.publish-crates.outputs.published).*
+        run: |
+          LIST="${{ join(fromJSON(steps.publish-crates.outputs.published).*.name, ', ') }}"
+          echo "Published crates: $LIST"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         id: publish-crates
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          dry-run: true
+          dry-run: ${{ github.event_name != 'push' }}
       - name: if my-crate published
         if: fromJSON(steps.publish-crates.outputs.published).*
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,16 +98,16 @@ jobs:
       ]
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@v10
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
-      - run: nix develop
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - uses: katyo/publish-crates@v2
         id: publish-crates
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           dry-run: ${{ github.event_name != 'push' }}
-      - name: if my-crate published
-        if: fromJSON(steps.publish-crates.outputs.published).*
+          ignore-unpublished-changes: true
+      - name: List published crates
+        if: ${{ steps.publish-crates.outputs.published != '' }}
         run: |
           LIST="${{ join(fromJSON(steps.publish-crates.outputs.published).*.name, ', ') }}"
           echo "Published crates: $LIST"

--- a/shell.nix
+++ b/shell.nix
@@ -8,6 +8,8 @@
 , rust-analyzer
 , rustfmt
 , curl
+, cargo
+, rustc
 }:
 mkShell {
   inputsFrom = [
@@ -21,5 +23,7 @@ mkShell {
     rqlite
     rust-analyzer
     rustfmt
+    cargo
+    rustc
   ];
 }


### PR DESCRIPTION
I'm pretty sure this is correct. It should just dry run on the PR but actually publish when merged to main. Will only publish if there's a bump to the toml version though.

I was thinking about triggering a release if anything is published but I don't know how that would work when only certain crates will publish.