### PR TITLE
feat: add contract and block subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,6 @@ dependencies = [
  "anyhow",
  "essential-hash",
  "essential-lock",
- "essential-server-types",
  "essential-state-read-vm",
  "essential-storage",
  "essential-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -61,33 +61,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -107,9 +107,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -276,9 +276,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cast"
@@ -288,9 +288,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.101"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac367972e516d45567c7eafc73d24e1c193dcf200a8d94e9db7b3d38b349572d"
+checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 
 [[package]]
 name = "cfg-if"
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.7"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -337,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.7"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
 dependencies = [
  "anstream",
  "anstyle",
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.5"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
+checksum = "5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cobs"
@@ -373,9 +373,9 @@ checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "const-oid"
@@ -731,6 +731,7 @@ dependencies = [
  "serde_json",
  "test-utils",
  "tokio",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",
@@ -1151,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http",
@@ -1186,9 +1187,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1240,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1319,9 +1320,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -1388,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "matchers"
@@ -1430,13 +1431,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
+ "hermit-abi",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1476,20 +1478,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "object"
-version = "0.36.0"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
 dependencies = [
  "memchr",
 ]
@@ -1502,15 +1494,15 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
-version = "11.1.3"
+version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -1540,9 +1532,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
@@ -1576,7 +1568,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1774,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -1860,10 +1852,12 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -1927,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.10"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1956,9 +1950,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2023,9 +2017,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation",
@@ -2036,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2052,18 +2046,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2072,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.118"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2219,9 +2213,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.68"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2306,18 +2300,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2346,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2361,28 +2355,27 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "d040ac2b29ab03b09d4129c2f5bbd012a3ac2f79d38ff506a4bf8dd34b0eac8a"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2605,9 +2598,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2701,6 +2694,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2756,7 +2762,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2776,18 +2782,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2798,9 +2804,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2810,9 +2816,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2822,15 +2828,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2840,9 +2846,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2852,9 +2858,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2864,9 +2870,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2876,9 +2882,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winreg"
@@ -2898,18 +2904,18 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,6 +697,7 @@ dependencies = [
  "anyhow",
  "essential-hash",
  "essential-lock",
+ "essential-server-types",
  "essential-state-read-vm",
  "essential-storage",
  "essential-types",
@@ -836,7 +837,9 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "essential-types",
+ "futures",
  "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -2281,6 +2284,7 @@ dependencies = [
  "essential-sign",
  "essential-storage",
  "essential-types",
+ "futures",
  "paste",
  "pretty_assertions",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ paste = "1.0.15"
 postcard = { version = "1.0.8", features = ["alloc"] }
 pretty_assertions = "1.4.0"
 rayon = "1.10"
-reqwest = "0.12.4"
+reqwest = "0.12.5"
 secp256k1 = { version = "0.29", features = ["rand-std", "hashes-std"] }
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.114"
@@ -41,6 +41,7 @@ sha2 = "0.10.8"
 tempfile = "3.10.0"
 thiserror = "1.0.58"
 tokio = { version = "1.36.0", features = ["full"] }
+tokio-util = { version = "0.7.11", features = ["codec", "io"]}
 tower = "0.4.13"
 tower-http = { version = "0.5.2", features = ["cors"] }
 tracing = {version = "0.1", features = ["attributes"]}

--- a/crates/memory-storage/Cargo.toml
+++ b/crates/memory-storage/Cargo.toml
@@ -14,6 +14,7 @@ essential-hash = { workspace = true }
 essential-lock = { workspace = true }
 essential-state-read-vm = { workspace = true }
 essential-storage = { workspace = true }
+essential-server-types.workspace = true
 essential-types = { workspace = true }
 futures = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/memory-storage/Cargo.toml
+++ b/crates/memory-storage/Cargo.toml
@@ -14,7 +14,6 @@ essential-hash = { workspace = true }
 essential-lock = { workspace = true }
 essential-state-read-vm = { workspace = true }
 essential-storage = { workspace = true }
-essential-server-types.workspace = true
 essential-types = { workspace = true }
 futures = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/memory-storage/src/lib.rs
+++ b/crates/memory-storage/src/lib.rs
@@ -301,6 +301,9 @@ impl Storage for MemoryStorage {
         futures::stream::unfold(init, move |state| {
             let storage = self.clone();
             essential_storage::streams::next_data(
+                new_contracts.clone(),
+                state,
+                PAGE_SIZE,
                 // List contracts expects a Range not a RangeFrom so we give it a range from
                 // start till the end of time.
                 move |get| {
@@ -311,9 +314,6 @@ impl Storage for MemoryStorage {
                             .await
                     }
                 },
-                new_contracts.clone(),
-                state,
-                PAGE_SIZE,
             )
         })
         .flat_map(futures::stream::iter)
@@ -396,6 +396,9 @@ impl Storage for MemoryStorage {
         futures::stream::unfold(init, move |state| {
             let storage = self.clone();
             essential_storage::streams::next_data(
+                new_blocks.clone(),
+                state,
+                PAGE_SIZE,
                 // List blocks expects a Range not a RangeFrom so we give it a range from
                 // start till the end of time.
                 move |get| {
@@ -410,9 +413,6 @@ impl Storage for MemoryStorage {
                             .await
                     }
                 },
-                new_blocks.clone(),
-                state,
-                PAGE_SIZE,
             )
         })
         .flat_map(futures::stream::iter)

--- a/crates/memory-storage/src/values/tests.rs
+++ b/crates/memory-storage/src/values/tests.rs
@@ -310,6 +310,63 @@ fn test_paging_blocks() {
     )
     .unwrap();
     assert_eq!(r, vec![]);
+
+    let r = page_blocks(&blocks, &solutions, &block_time_index, None, Some(5), 0, 1).unwrap();
+    assert_eq!(r, vec![expected.get(&duration_secs(5)).unwrap().clone()]);
+
+    let r = page_blocks(&blocks, &solutions, &block_time_index, None, Some(5), 2, 1).unwrap();
+    assert_eq!(r, vec![expected.get(&duration_secs(7)).unwrap().clone()]);
+
+    let r = page_blocks(&blocks, &solutions, &block_time_index, None, Some(10), 0, 1).unwrap();
+    assert_eq!(r, vec![]);
+
+    let r = page_blocks(
+        &blocks,
+        &solutions,
+        &block_time_index,
+        Some(duration_secs(3)..duration_secs(5)),
+        Some(1),
+        0,
+        1,
+    )
+    .unwrap();
+    assert_eq!(r, vec![expected.get(&duration_secs(3)).unwrap().clone()]);
+
+    let r = page_blocks(
+        &blocks,
+        &solutions,
+        &block_time_index,
+        Some(duration_secs(3)..duration_secs(5)),
+        Some(4),
+        0,
+        1,
+    )
+    .unwrap();
+    assert_eq!(r, vec![expected.get(&duration_secs(4)).unwrap().clone()]);
+
+    let r = page_blocks(
+        &blocks,
+        &solutions,
+        &block_time_index,
+        Some(duration_secs(3)..duration_secs(5)),
+        Some(4),
+        0,
+        10,
+    )
+    .unwrap();
+    assert_eq!(r, vec![expected.get(&duration_secs(4)).unwrap().clone()]);
+
+    let r = page_blocks(
+        &blocks,
+        &solutions,
+        &block_time_index,
+        Some(duration_secs(3)..duration_secs(5)),
+        Some(6),
+        0,
+        10,
+    )
+    .unwrap();
+    assert_eq!(r, vec![]);
 }
 
 #[test]

--- a/crates/memory-storage/src/values/tests.rs
+++ b/crates/memory-storage/src/values/tests.rs
@@ -240,14 +240,15 @@ fn test_paging_blocks() {
             )
         })
         .collect();
+    let block_time_index: HashMap<_, _> = blocks.iter().map(|(d, b)| (b.number, *d)).collect();
 
-    let r = page_winning_blocks(&blocks, &solutions, None, 0, 1).unwrap();
+    let r = page_blocks(&blocks, &solutions, &block_time_index, None, None, 0, 1).unwrap();
     assert_eq!(r, vec![expected.get(&duration_secs(0)).unwrap().clone()]);
 
-    let r = page_winning_blocks(&blocks, &solutions, None, 1, 1).unwrap();
+    let r = page_blocks(&blocks, &solutions, &block_time_index, None, None, 1, 1).unwrap();
     assert_eq!(r, vec![expected.get(&duration_secs(1)).unwrap().clone()]);
 
-    let r = page_winning_blocks(&blocks, &solutions, None, 1, 2).unwrap();
+    let r = page_blocks(&blocks, &solutions, &block_time_index, None, None, 1, 2).unwrap();
     assert_eq!(
         r,
         vec![
@@ -256,20 +257,24 @@ fn test_paging_blocks() {
         ]
     );
 
-    let r = page_winning_blocks(
+    let r = page_blocks(
         &blocks,
         &solutions,
+        &block_time_index,
         Some(duration_secs(0)..duration_secs(10)),
+        None,
         0,
         1,
     )
     .unwrap();
     assert_eq!(r, vec![expected.get(&duration_secs(0)).unwrap().clone()]);
 
-    let r = page_winning_blocks(
+    let r = page_blocks(
         &blocks,
         &solutions,
+        &block_time_index,
         Some(duration_secs(0)..duration_secs(10)),
+        None,
         0,
         2,
     )
@@ -282,20 +287,24 @@ fn test_paging_blocks() {
         ]
     );
 
-    let r = page_winning_blocks(
+    let r = page_blocks(
         &blocks,
         &solutions,
+        &block_time_index,
         Some(duration_secs(1)..duration_secs(2)),
+        None,
         0,
         2,
     )
     .unwrap();
     assert_eq!(r, vec![expected.get(&duration_secs(1)).unwrap().clone()]);
 
-    let r = page_winning_blocks(
+    let r = page_blocks(
         &blocks,
         &solutions,
+        &block_time_index,
         Some(duration_secs(1)..duration_secs(1)),
+        None,
         0,
         2,
     )

--- a/crates/rest-server/Cargo.toml
+++ b/crates/rest-server/Cargo.toml
@@ -35,9 +35,10 @@ tracing-subscriber = { workspace = true, optional = true, features = [
 essential-hash = { workspace = true }
 essential-state-read-vm = { workspace = true }
 essential-storage = { workspace = true }
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true, features = ["json", "stream"] }
 serde_json = { workspace = true }
 test-utils = { workspace = true }
+tokio-util.workspace = true
 
 [features]
 default = ["tracing"]

--- a/crates/rest-server/README.md
+++ b/crates/rest-server/README.md
@@ -66,6 +66,7 @@ Returns: `Option<Predicate>` as JSON
 ```bash
 curl --http2-prior-knowledge -X GET -H "Content-Type: application/json" http://localhost:59498/get-predicate/EE3F28F3E0396EEE29613AF73E65D2BA52AE606E5FFD14D5EBD02A0FB5B88236/709E80C88487A2411E1EE4DFB9F22A861492D20C4765150C0C794ABD70F8147C
 ```
+
 ### GET `/list-contracts`
 Query parameters: 
 - *Optional* `{ start: u64, end: u64 }`. This is the time range to list contract within. It is inclusive of the start and exclusive of the end.
@@ -77,6 +78,21 @@ Returns: `Vec<Contract>` as JSON
 ```bash
 curl --http2-prior-knowledge -X GET -H "Content-Type: application/json" "http://localhost:59498/list-contracts?start=0&end=1&page=0"
 ```
+
+### GET `/subscribe-contracts`
+This api is a server sent event api.\
+This allows you to subscribe to new contracts as they are deployed.
+Query parameters: 
+- *Optional* `{ start: u64 }`. This is the time to start returning contracts from.
+- *Optional* `{ page: u64 }`. This is the page number to return contracts from. The default is 0.
+
+Returns: `Stream<Item = Result<Contract>>` where the result and contract are json.
+
+**Example:**
+```bash
+curl --http2-prior-knowledge -N -X GET -H "Content-Type: application/json" "http://localhost:59498/subscribe-blocks?start=0&end=1&page=0&block=0"
+```
+
 ### POST `/submit-solution`
 Body: `Solution` as JSON \
 Returns: `Hash` as JSON
@@ -106,17 +122,35 @@ Returns: `Option<Word>` as JSON
 ```bash
 curl --http2-prior-knowledge -X GET -H "Content-Type: application/json" http://localhost:59498/query-state/EE3F28F3E0396EEE29613AF73E65D2BA52AE606E5FFD14D5EBD02A0FB5B88236/00
 ```
+
 ### GET `/list-blocks`
 Query parameters: 
-- *Optional* `{ start: u64, end: u64 }`. This is the time range to list contract within. It is inclusive of the start and exclusive of the end.
-- *Optional* `{ page: u64 }`. This is the page number to list contracts from. The default is 0.
+- *Optional* `{ start: u64, end: u64 }`. This is the time range to list blocks within. It is inclusive of the start and exclusive of the end.
+- *Optional* `{ page: u64 }`. This is the page number to list blocks from. The default is 0.
+- *Optional* `{ block: u64 }`. This is the block number to list blocks from.
 
 Returns: `Vec<Block>` as JSON
 
 **Example:**
 ```bash
-curl --http2-prior-knowledge -X GET -H "Content-Type: application/json" "http://localhost:59498/list-blocks?start=0&end=1&page=0"
+curl --http2-prior-knowledge -X GET -H "Content-Type: application/json" "http://localhost:59498/list-blocks?start=0&end=1&page=0&block=0"
 ```
+
+### GET `/subscribe-blocks`
+This api is a server sent event api.\
+This allows you to subscribe to new blocks as they are added to the chain.
+Query parameters: 
+- *Optional* `{ start: u64 }`. This is the time to start returning blocks from.
+- *Optional* `{ page: u64 }`. This is the page number to return blocks from. The default is 0.
+- *Optional* `{ block: u64 }`. This is the block number to return blocks from.
+
+Returns: `Stream<Item = Result<Block>>` where the result and block are json.
+
+**Example:**
+```bash
+curl --http2-prior-knowledge -N -X GET -H "Content-Type: application/json" "http://localhost:59498/subscribe-blocks?start=0&end=1&page=0&block=0"
+```
+
 ### GET `/solution-outcome/:hash`
 Parameters: 
 - `:hash` = `[u8; 32]` as hex string. This is the hash of the solution.

--- a/crates/rest-server/src/lib.rs
+++ b/crates/rest-server/src/lib.rs
@@ -6,7 +6,10 @@
 use anyhow::anyhow;
 use axum::{
     extract::{Path, Query, State},
-    response::{sse::Event, IntoResponse, Sse},
+    response::{
+        sse::{Event, KeepAlive},
+        IntoResponse, Sse,
+    },
     routing::{get, post},
     Json, Router,
 };
@@ -347,6 +350,7 @@ where
             .map::<Result<_, Error>, _>(|contract| Ok(Event::default().json_data(contract?)?))
             .map(|r| r.map_err(StdError)),
     )
+    .keep_alive(KeepAlive::default())
 }
 
 /// The list blocks get endpoint.
@@ -399,6 +403,7 @@ where
             .map::<Result<_, Error>, _>(|block| Ok(Event::default().json_data(block?)?))
             .map(|r| r.map_err(StdError)),
     )
+    .keep_alive(KeepAlive::default())
 }
 
 /// The list solutions pool get endpoint.

--- a/crates/rest-server/src/lib.rs
+++ b/crates/rest-server/src/lib.rs
@@ -355,6 +355,7 @@ where
 async fn list_blocks<S>(
     State(essential): State<Essential<S>>,
     time_range: Option<Query<TimeRange>>,
+    block: Option<Query<BlockNumber>>,
     page: Option<Query<Page>>,
 ) -> Result<Json<Vec<Block>>, Error>
 where
@@ -366,7 +367,11 @@ where
         time_range.map(|range| Duration::from_secs(range.start)..Duration::from_secs(range.end));
 
     let blocks = essential
-        .list_blocks(time_range, page.map(|p| p.page as usize))
+        .list_blocks(
+            time_range,
+            block.map(|b| b.block),
+            page.map(|p| p.page as usize),
+        )
         .await?;
     Ok(Json(blocks))
 }

--- a/crates/rest-server/tests/curl.rs
+++ b/crates/rest-server/tests/curl.rs
@@ -53,8 +53,15 @@ async fn test_readme_curl() {
 
     for c in &commands {
         let mut command = Command::new("curl");
+        let mut stream = false;
         for arg in c.iter().skip(1) {
+            if arg == "-N" {
+                stream = true;
+            }
             command.arg(arg);
+        }
+        if stream {
+            continue;
         }
         let output = command.output().await.unwrap();
         let s = String::from_utf8_lossy(&output.stdout);

--- a/crates/rest-server/tests/integration.rs
+++ b/crates/rest-server/tests/integration.rs
@@ -461,7 +461,11 @@ async fn test_subscribe_blocks() {
 
     let response = client.get(a).send().await.unwrap();
     assert_eq!(response.status(), 200);
-    let result: Vec<_> = make_stream(response).take(2).try_collect().await.unwrap();
+    let result: Vec<_> = make_stream(response)
+        .take_until(tokio::time::sleep(Duration::from_millis(50)))
+        .try_collect()
+        .await
+        .unwrap();
     assert_eq!(result.len(), 2);
     assert_eq!(result[0].number, 0);
     assert_eq!(result[1].number, 1);
@@ -483,7 +487,11 @@ async fn test_subscribe_blocks() {
     let block = s.try_next().await.unwrap().unwrap();
     assert_eq!(block.number, 100);
 
-    let blocks: Vec<_> = s.take(98).try_collect().await.unwrap();
+    let blocks: Vec<_> = s
+        .take_until(tokio::time::sleep(Duration::from_millis(50)))
+        .try_collect()
+        .await
+        .unwrap();
     assert_eq!(blocks.len(), 98);
     assert_eq!(blocks[97].number, 198);
 
@@ -494,7 +502,11 @@ async fn test_subscribe_blocks() {
     assert_eq!(response.status(), 200);
     let s = make_stream(response);
 
-    let blocks: Vec<_> = s.take(9).try_collect().await.unwrap();
+    let blocks: Vec<_> = s
+        .take_until(tokio::time::sleep(Duration::from_millis(50)))
+        .try_collect()
+        .await
+        .unwrap();
     assert_eq!(blocks.len(), 9);
     assert_eq!(blocks[8].number, 198);
 
@@ -508,7 +520,11 @@ async fn test_subscribe_blocks() {
 
     let s = make_stream(response);
 
-    let blocks: Vec<_> = s.take(9).try_collect().await.unwrap();
+    let blocks: Vec<_> = s
+        .take_until(tokio::time::sleep(Duration::from_millis(50)))
+        .try_collect()
+        .await
+        .unwrap();
     assert_eq!(blocks.len(), 9);
     assert_eq!(blocks[8].number, 198);
 
@@ -548,4 +564,183 @@ fn make_stream(response: reqwest::Response) -> impl futures::Stream<Item = anyho
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{}", e))),
     );
     FramedRead::new(stream, BlockDecoder {})
+}
+
+fn contract_with_salt(salt: Word) -> Contract {
+    let mut s = [0; 32];
+    s[0..8].copy_from_slice(&bytes_from_word(salt));
+    Contract {
+        predicates: vec![],
+        salt: s,
+    }
+}
+
+#[tokio::test]
+async fn test_subscribe_contracts() {
+    let contracts: Vec<_> = (0..200)
+        .map(contract_with_salt)
+        .map(|mut c| {
+            c.predicates.push(Predicate::empty());
+            c
+        })
+        .map(sign_contract_with_random_keypair)
+        .collect();
+
+    let mem = MemoryStorage::new();
+    mem.insert_contract(contracts[0].clone()).await.unwrap();
+
+    let TestServer {
+        client,
+        url,
+        shutdown,
+        jh,
+    } = setup_with_mem(mem.clone()).await;
+
+    let a = url.join("/subscribe-contracts").unwrap();
+    let response = client.get(a).send().await.unwrap();
+    assert_eq!(response.status(), 200);
+    let mut s = make_contract_stream(response);
+
+    let contract = s.try_next().await.unwrap().unwrap();
+    assert_eq!(contract, contracts[0].contract);
+
+    let r = tokio::time::timeout(Duration::from_millis(50), s.try_next()).await;
+    assert!(r.is_err());
+
+    for contract in &contracts[1..3] {
+        mem.insert_contract(contract.clone()).await.unwrap();
+    }
+
+    let result: Vec<_> = s
+        .take_until(tokio::time::sleep(Duration::from_millis(50)))
+        .try_collect()
+        .await
+        .unwrap();
+
+    for (contract, result) in contracts[1..3].iter().zip(result) {
+        assert_eq!(contract.contract, result);
+    }
+
+    let mut a = url.join("/subscribe-contracts").unwrap();
+    a.query_pairs_mut().append_pair("page", "0");
+
+    let response = client.get(a).send().await.unwrap();
+    assert_eq!(response.status(), 200);
+    let result: Vec<_> = make_contract_stream(response)
+        .take_until(tokio::time::sleep(Duration::from_millis(50)))
+        .try_collect()
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 3);
+    for (contract, result) in contracts[0..3].iter().zip(result) {
+        assert_eq!(contract.contract, result);
+    }
+
+    let mut a = url.join("/subscribe-contracts").unwrap();
+    a.query_pairs_mut().append_pair("page", "1");
+
+    let response = client.get(a).send().await.unwrap();
+    assert_eq!(response.status(), 200);
+    let mut s = make_contract_stream(response);
+
+    let r = tokio::time::timeout(Duration::from_millis(50), s.try_next()).await;
+    assert!(r.is_err());
+
+    for contract in &contracts[3..] {
+        mem.insert_contract(contract.clone()).await.unwrap();
+    }
+
+    let contract = s.try_next().await.unwrap().unwrap();
+    assert_eq!(contract, contracts[100].contract);
+
+    let results: Vec<_> = s
+        .take_until(tokio::time::sleep(Duration::from_millis(50)))
+        .try_collect()
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 99);
+    assert_eq!(results[98], contracts[199].contract);
+
+    let time = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap();
+    let start = time - std::time::Duration::from_secs(100);
+    let mut a = url.join("/subscribe-contracts").unwrap();
+    a.query_pairs_mut()
+        .append_pair("start", start.as_secs().to_string().as_str());
+
+    let response = client.get(a).send().await.unwrap();
+    assert_eq!(response.status(), 200);
+    let s = make_contract_stream(response);
+
+    let results: Vec<_> = s
+        .take_until(tokio::time::sleep(Duration::from_millis(50)))
+        .try_collect()
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 200);
+    assert_eq!(results[199], contracts[199].contract);
+
+    let mut a = url.join("/subscribe-contracts").unwrap();
+    a.query_pairs_mut()
+        .append_pair("start", start.as_secs().to_string().as_str())
+        .append_pair("page", "1");
+
+    let response = client.get(a).send().await.unwrap();
+    assert_eq!(response.status(), 200);
+
+    let s = make_contract_stream(response);
+
+    let results: Vec<_> = s
+        .take_until(tokio::time::sleep(Duration::from_millis(50)))
+        .try_collect()
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 100);
+    for (contract, result) in contracts[100..].iter().zip(results) {
+        assert_eq!(contract.contract, result);
+    }
+
+    shutdown.send(()).unwrap();
+    jh.await.unwrap().unwrap();
+}
+
+struct ContractDecoder {}
+
+impl Decoder for ContractDecoder {
+    type Item = Contract;
+    type Error = anyhow::Error;
+
+    fn decode(&mut self, buf: &mut bytes::BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        let end = buf
+            .iter()
+            .zip(buf.iter().skip(1))
+            .position(|(&a, &b)| a == b'\n' && b == b'\n');
+
+        match end {
+            Some(end) => {
+                let s = std::str::from_utf8(&buf[..end])?;
+                let s = s.trim_start_matches("data: ").trim();
+                let contract = serde_json::from_str::<Contract>(s);
+                buf.advance(end + 2);
+                let Ok(contract) = contract else {
+                    return Ok(None);
+                };
+                Ok(Some(contract))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+fn make_contract_stream(
+    response: reqwest::Response,
+) -> impl futures::Stream<Item = anyhow::Result<Contract>> {
+    let stream = StreamReader::new(
+        response
+            .bytes_stream()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{}", e))),
+    );
+    FramedRead::new(stream, ContractDecoder {})
 }

--- a/crates/rqlite-storage/sql/query/list_winning_batches.sql
+++ b/crates/rqlite-storage/sql/query/list_winning_batches.sql
@@ -13,6 +13,8 @@ WHERE
             id
         FROM
             batch
+        WHERE
+            id > :block_number
         ORDER BY
             id ASC
         LIMIT

--- a/crates/rqlite-storage/sql/query/list_winning_batches_by_time.sql
+++ b/crates/rqlite-storage/sql/query/list_winning_batches_by_time.sql
@@ -14,7 +14,8 @@ WHERE
         FROM
             batch
         WHERE
-            (
+            id > :block_number
+            AND (
                 created_at_seconds > :start_seconds
                 OR (
                     created_at_seconds = :start_seconds

--- a/crates/rqlite-storage/src/lib.rs
+++ b/crates/rqlite-storage/src/lib.rs
@@ -650,6 +650,8 @@ impl Storage for RqliteStorage {
             Ok(Vec::new())
         };
 
+        let new_block = !solved.is_empty();
+
         let r = r.and_then(|mut sql| {
             let r = if !solved.is_empty() {
                 move_solutions_to_solved(solved)
@@ -676,8 +678,10 @@ impl Storage for RqliteStorage {
             let sql: Vec<&[serde_json::Value]> = sql.iter().map(|v| v.as_slice()).collect();
             let r = self.execute(&sql[..]).await;
 
-            // Notify the streams of the new blocks.
-            self.streams.notify_new_blocks();
+            if new_block {
+                // Notify the streams of the new blocks.
+                self.streams.notify_new_blocks();
+            }
 
             r
         }

--- a/crates/rqlite-storage/src/lib.rs
+++ b/crates/rqlite-storage/src/lib.rs
@@ -510,6 +510,9 @@ impl Storage for RqliteStorage {
         futures::stream::unfold(init, move |state| {
             let storage = self.clone();
             essential_storage::streams::next_data(
+                new_contracts.clone(),
+                state,
+                PAGE_SIZE,
                 // List contracts expects a Range not a RangeFrom so we give it a range from
                 // start till the end of time.
                 move |get| {
@@ -520,9 +523,6 @@ impl Storage for RqliteStorage {
                             .await
                     }
                 },
-                new_contracts.clone(),
-                state,
-                PAGE_SIZE,
             )
         })
         .flat_map(futures::stream::iter)
@@ -595,6 +595,9 @@ impl Storage for RqliteStorage {
         futures::stream::unfold(init, move |state| {
             let storage = self.clone();
             essential_storage::streams::next_data(
+                new_blocks.clone(),
+                state,
+                PAGE_SIZE,
                 // List blocks expects a Range not a RangeFrom so we give it a range from
                 // start till the end of time.
                 move |get| {
@@ -609,9 +612,6 @@ impl Storage for RqliteStorage {
                             .await
                     }
                 },
-                new_blocks.clone(),
-                state,
-                PAGE_SIZE,
             )
         })
         .flat_map(futures::stream::iter)

--- a/crates/rqlite-storage/tests/sql_solutions.rs
+++ b/crates/rqlite-storage/tests/sql_solutions.rs
@@ -127,6 +127,7 @@ fn test_insert_solutions() {
         &conn,
         include_sql!("query", "list_winning_batches"),
         named_params! {
+            ":block_number": 0,
             ":page_size": 10,
             ":page_number": 0,
         },
@@ -376,6 +377,7 @@ fn test_batch_paging() {
         &conn,
         include_sql!("query", "list_winning_batches"),
         named_params! {
+            ":block_number": 0,
             ":page_size": 2,
             ":page_number": 0,
         },
@@ -402,6 +404,7 @@ fn test_batch_paging() {
         &conn,
         include_sql!("query", "list_winning_batches"),
         named_params! {
+            ":block_number": 0,
             ":page_size": 2,
             ":page_number": 1,
         },
@@ -428,6 +431,7 @@ fn test_batch_paging() {
         &conn,
         include_sql!("query", "list_winning_batches"),
         named_params! {
+            ":block_number": 0,
             ":page_size": 2,
             ":page_number": 20,
         },
@@ -452,8 +456,63 @@ fn test_batch_paging() {
 
     let result = query(
         &conn,
+        include_sql!("query", "list_winning_batches"),
+        named_params! {
+            ":block_number": 10,
+            ":page_size": 2,
+            ":page_number": 0,
+        },
+        |row| {
+            (
+                row.get::<_, usize>(0).unwrap(),
+                row.get::<_, String>(1).unwrap(),
+                row.get::<_, usize>(2).unwrap(),
+                row.get::<_, usize>(3).unwrap(),
+            )
+        },
+    );
+    assert_eq!(
+        result,
+        vec![
+            (10, "solution18".to_string(), 9 * 100, 9 * 100),
+            (10, "solution19".to_string(), 9 * 100, 9 * 100,),
+            (11, "solution20".to_string(), 10 * 100, 10 * 100,),
+            (11, "solution21".to_string(), 10 * 100, 10 * 100,),
+        ]
+    );
+
+    let result = query(
+        &conn,
+        include_sql!("query", "list_winning_batches"),
+        named_params! {
+            ":block_number": 10,
+            ":page_size": 2,
+            ":page_number": 1,
+        },
+        |row| {
+            (
+                row.get::<_, usize>(0).unwrap(),
+                row.get::<_, String>(1).unwrap(),
+                row.get::<_, usize>(2).unwrap(),
+                row.get::<_, usize>(3).unwrap(),
+            )
+        },
+    );
+    assert_eq!(
+        result,
+        vec![
+            (12, "solution22".to_string(), 11 * 100, 11 * 100),
+            (12, "solution23".to_string(), 11 * 100, 11 * 100,),
+            (13, "solution24".to_string(), 12 * 100, 12 * 100,),
+            (13, "solution25".to_string(), 12 * 100, 12 * 100,),
+        ]
+    );
+
+    let result = query(
+        &conn,
         include_sql!("query", "list_winning_batches_by_time"),
         named_params! {
+            ":block_number": 40,
             ":page_size": 1,
             ":page_number": 2,
             ":start_seconds": 40 * 100,
@@ -482,6 +541,36 @@ fn test_batch_paging() {
         &conn,
         include_sql!("query", "list_winning_batches_by_time"),
         named_params! {
+            ":block_number": 44,
+            ":page_size": 1,
+            ":page_number": 2,
+            ":start_seconds": 40 * 100,
+            ":start_nanos": 100,
+            ":end_seconds": 100 * 100,
+            ":end_nanos": 100 * 100,
+        },
+        |row| {
+            (
+                row.get::<_, usize>(0).unwrap(),
+                row.get::<_, String>(1).unwrap(),
+                row.get::<_, usize>(2).unwrap(),
+                row.get::<_, usize>(3).unwrap(),
+            )
+        },
+    );
+    assert_eq!(
+        result,
+        vec![
+            (46, "solution90".to_string(), 45 * 100, 45 * 100),
+            (46, "solution91".to_string(), 45 * 100, 45 * 100,),
+        ]
+    );
+
+    let result = query(
+        &conn,
+        include_sql!("query", "list_winning_batches_by_time"),
+        named_params! {
+            ":block_number": 0,
             ":page_size": 1,
             ":page_number": 0,
             ":start_seconds": 41 * 100,

--- a/crates/rqlite-storage/tests/sql_solutions.rs
+++ b/crates/rqlite-storage/tests/sql_solutions.rs
@@ -474,10 +474,10 @@ fn test_batch_paging() {
     assert_eq!(
         result,
         vec![
-            (10, "solution18".to_string(), 9 * 100, 9 * 100),
-            (10, "solution19".to_string(), 9 * 100, 9 * 100,),
-            (11, "solution20".to_string(), 10 * 100, 10 * 100,),
+            (11, "solution20".to_string(), 10 * 100, 10 * 100),
             (11, "solution21".to_string(), 10 * 100, 10 * 100,),
+            (12, "solution22".to_string(), 11 * 100, 11 * 100,),
+            (12, "solution23".to_string(), 11 * 100, 11 * 100,),
         ]
     );
 
@@ -501,10 +501,10 @@ fn test_batch_paging() {
     assert_eq!(
         result,
         vec![
-            (12, "solution22".to_string(), 11 * 100, 11 * 100),
-            (12, "solution23".to_string(), 11 * 100, 11 * 100,),
-            (13, "solution24".to_string(), 12 * 100, 12 * 100,),
+            (13, "solution24".to_string(), 12 * 100, 12 * 100),
             (13, "solution25".to_string(), 12 * 100, 12 * 100,),
+            (14, "solution26".to_string(), 13 * 100, 13 * 100,),
+            (14, "solution27".to_string(), 13 * 100, 13 * 100,),
         ]
     );
 
@@ -561,8 +561,8 @@ fn test_batch_paging() {
     assert_eq!(
         result,
         vec![
-            (46, "solution90".to_string(), 45 * 100, 45 * 100),
-            (46, "solution91".to_string(), 45 * 100, 45 * 100,),
+            (47, "solution92".to_string(), 46 * 100, 46 * 100),
+            (47, "solution93".to_string(), 46 * 100, 46 * 100,),
         ]
     );
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -183,6 +183,16 @@ where
         self.storage.list_contracts(time_range, page).await
     }
 
+    pub fn subscribe_contracts(
+        &self,
+        start_time: Option<Duration>,
+        start_page: Option<usize>,
+    ) -> impl futures::stream::Stream<Item = anyhow::Result<Contract>> + Send + 'static {
+        self.storage
+            .clone()
+            .subscribe_contracts(start_time, start_page)
+    }
+
     pub async fn list_solutions_pool(&self, page: Option<usize>) -> anyhow::Result<Vec<Solution>> {
         self.storage.list_solutions_pool(page).await
     }
@@ -193,6 +203,17 @@ where
         page: Option<usize>,
     ) -> anyhow::Result<Vec<Block>> {
         self.storage.list_blocks(time_range, page).await
+    }
+
+    pub fn subscribe_blocks(
+        &self,
+        start_time: Option<Duration>,
+        start_number: Option<u64>,
+        start_page: Option<usize>,
+    ) -> impl futures::stream::Stream<Item = anyhow::Result<Block>> + Send + 'static {
+        self.storage
+            .clone()
+            .subscribe_blocks(start_time, start_number, start_page)
     }
 
     pub async fn query_state(

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -200,9 +200,12 @@ where
     pub async fn list_blocks(
         &self,
         time_range: Option<Range<Duration>>,
+        block_number: Option<u64>,
         page: Option<usize>,
     ) -> anyhow::Result<Vec<Block>> {
-        self.storage.list_blocks(time_range, page).await
+        self.storage
+            .list_blocks(time_range, block_number, page)
+            .await
     }
 
     pub fn subscribe_blocks(

--- a/crates/server/src/run/tests.rs
+++ b/crates/server/src/run/tests.rs
@@ -51,7 +51,7 @@ async fn test_run() {
         .unwrap();
     assert_eq!(post_state, vec![42]);
 
-    let blocks = storage.list_blocks(None, None).await.unwrap();
+    let blocks = storage.list_blocks(None, None, None).await.unwrap();
     assert_eq!(blocks.len(), 1);
     assert_eq!(blocks[0].solutions.len(), 1);
     assert_eq!(blocks[0].solutions[0], solution);
@@ -64,7 +64,7 @@ async fn test_run() {
 
     run(&storage).await.unwrap();
 
-    let blocks = storage.list_blocks(None, None).await.unwrap();
+    let blocks = storage.list_blocks(None, None, None).await.unwrap();
     assert_eq!(blocks.len(), 2);
     assert_eq!(blocks[1].solutions.len(), 1);
     assert!(blocks[1].solutions.iter().any(|s| s == &solution3));
@@ -104,7 +104,7 @@ async fn test_counter() {
         .unwrap();
     assert_eq!(post_state, vec![2]);
 
-    let blocks = storage.list_blocks(None, None).await.unwrap();
+    let blocks = storage.list_blocks(None, None, None).await.unwrap();
     assert_eq!(blocks.len(), 1);
     assert_eq!(blocks[0].solutions.len(), 2);
     let solutions = &blocks[0].solutions;
@@ -122,7 +122,7 @@ async fn test_counter() {
         .unwrap();
     assert_eq!(post_state, vec![4]);
 
-    let blocks = storage.list_blocks(None, None).await.unwrap();
+    let blocks = storage.list_blocks(None, None, None).await.unwrap();
     assert_eq!(blocks.len(), 2);
     assert_eq!(blocks[1].solutions.len(), 2);
     let solutions = &blocks[1].solutions;

--- a/crates/server/tests/tests.rs
+++ b/crates/server/tests/tests.rs
@@ -37,7 +37,7 @@ where
     server.submit_solution(solution.clone()).await.unwrap();
 
     let blocks = loop {
-        let blocks = server.list_blocks(None, None).await.unwrap();
+        let blocks = server.list_blocks(None, None, None).await.unwrap();
         if !blocks.is_empty() {
             break blocks;
         }
@@ -55,7 +55,7 @@ where
     server.submit_solution(solution.clone()).await.unwrap();
 
     let blocks = loop {
-        let blocks = server.list_blocks(None, None).await.unwrap();
+        let blocks = server.list_blocks(None, None, None).await.unwrap();
         if blocks.len() > 1 {
             break blocks;
         }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -11,4 +11,6 @@ repository.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 essential-types = { workspace = true }
+futures.workspace = true
 serde = { workspace = true }
+tokio.workspace = true

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -105,6 +105,7 @@ pub trait Storage: StateStorage {
     fn list_blocks(
         &self,
         time_range: Option<Range<Duration>>,
+        block_number: Option<u64>,
         page: Option<usize>,
     ) -> impl Future<Output = anyhow::Result<Vec<Block>>> + Send;
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -15,6 +15,8 @@ use failed_solution::{FailedSolution, SolutionFailReason, SolutionOutcomes};
 
 /// Module for failed solution struct.
 pub mod failed_solution;
+/// Module for streams.
+pub mod streams;
 
 /// Data to commit after a block has been built.
 /// This data should all be committed atomically.
@@ -78,6 +80,15 @@ pub trait Storage: StateStorage {
         page: Option<usize>,
     ) -> impl Future<Output = anyhow::Result<Vec<Contract>>> + Send;
 
+    /// Subscribe to new contracts from a given start page or start time.
+    /// This will return all the contracts from that point then continue to stream
+    /// as new contracts are added.
+    fn subscribe_contracts(
+        self,
+        start_time: Option<Duration>,
+        start_page: Option<usize>,
+    ) -> impl futures::Stream<Item = anyhow::Result<Contract>> + Send + 'static;
+
     /// List all solutions in the pool.
     fn list_solutions_pool(
         &self,
@@ -96,6 +107,16 @@ pub trait Storage: StateStorage {
         time_range: Option<Range<Duration>>,
         page: Option<usize>,
     ) -> impl Future<Output = anyhow::Result<Vec<Block>>> + Send;
+
+    /// Subscribe to new blocks from a given block number or start page or start time.
+    /// This will return all the blocks from that point then continue to stream
+    /// as new blocks are added.
+    fn subscribe_blocks(
+        self,
+        start_time: Option<Duration>,
+        block_number: Option<u64>,
+        start_page: Option<usize>,
+    ) -> impl futures::Stream<Item = anyhow::Result<Block>> + Send + 'static;
 
     /// Get failed solution and its failing reason.
     fn get_solution(

--- a/crates/storage/src/streams.rs
+++ b/crates/storage/src/streams.rs
@@ -1,0 +1,197 @@
+use std::time::Duration;
+
+#[cfg(test)]
+mod tests;
+
+/// Notify that there are new contracts or blocks.
+#[derive(Clone)]
+pub struct Notify {
+    contracts: tokio::sync::watch::Sender<()>,
+    blocks: tokio::sync::watch::Sender<()>,
+}
+
+/// Wait for new data.
+#[derive(Clone)]
+pub struct NewData(tokio::sync::watch::Receiver<()>);
+
+/// State of the stream.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StreamState {
+    state: State,
+    start: Start,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum State {
+    Pos(Pos),
+    Done,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct Pos {
+    page: usize,
+    index: usize,
+}
+
+/// Get data from this point.
+#[derive(Default, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct GetData {
+    /// Page number to get data from.
+    pub page: usize,
+    /// Time to get data from.
+    pub time: Option<Duration>,
+    /// Number to get data from.
+    pub number: Option<u64>,
+}
+
+#[derive(Default, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct Start {
+    time: Option<Duration>,
+    number: Option<u64>,
+}
+
+/// Get the next data in the stream.
+pub async fn next_data<F, Fut, D>(
+    get_data: F,
+    mut new_data: NewData,
+    state: StreamState,
+    page_size: usize,
+) -> Option<(Vec<anyhow::Result<D>>, StreamState)>
+where
+    F: Fn(GetData) -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<Vec<D>>>,
+{
+    // Check if the stream is done due to returning an error.
+    let pos = match state.state {
+        State::Pos(pos) => pos,
+        State::Done => return None,
+    };
+
+    // Loop while there are no new data to return but there has been a change in contracts.
+    loop {
+        // List the data for this page
+        let data = get_data(GetData {
+            page: pos.page,
+            time: state.start.time,
+            number: state.start.number,
+        })
+        .await;
+
+        match data {
+            // If there are no data for this page, await a change.
+            Ok(data) if data.get(pos.index..).filter(|d| !d.is_empty()).is_none() => {
+                match new_data.wait().await {
+                    // Got a change, get data again.
+                    Ok(_) => continue,
+                    // The new data channel was closed, this means
+                    // the program is shutting down. Close this stream.
+                    Err(_) => return None,
+                }
+            }
+            // There is some data to return.
+            Ok(mut data) => {
+                // Calculate the next page and index.
+                let next_page = if data.len() >= page_size {
+                    Pos {
+                        page: pos.page + 1,
+                        index: 0,
+                    }
+                } else {
+                    Pos {
+                        page: pos.page,
+                        index: data.len(),
+                    }
+                };
+
+                // Drain just the new data (this should never be empty due to the above check).
+                return Some((
+                    data.drain(pos.index..).map(Ok).collect::<Vec<_>>(),
+                    StreamState {
+                        state: State::Pos(next_page),
+                        start: state.start,
+                    },
+                ));
+            }
+            // Got an error so return the error and mark the stream as done.
+            Err(e) => {
+                return Some((
+                    vec![Err(e)],
+                    StreamState {
+                        state: State::Done,
+                        start: state.start,
+                    },
+                ))
+            }
+        }
+    }
+}
+
+impl StreamState {
+    /// Create a new stream state from a page.
+    pub fn new(page: Option<usize>, time: Option<Duration>, number: Option<u64>) -> Self {
+        let page = page.unwrap_or(0);
+        Self {
+            state: State::Pos(Pos { page, index: 0 }),
+            start: Start { time, number },
+        }
+    }
+}
+
+impl Notify {
+    /// Create a new notify.
+    pub fn new() -> Self {
+        let (contracts, _) = tokio::sync::watch::channel(());
+        let (blocks, _) = tokio::sync::watch::channel(());
+        Self { contracts, blocks }
+    }
+
+    /// Notify that there are new contracts.
+    pub fn notify_new_contracts(&self) {
+        // There might not be any subscribers so we
+        // need to ignore the error.
+        let _ = self.contracts.send(());
+    }
+
+    /// Notify that there are new blocks.
+    pub fn notify_new_blocks(&self) {
+        // There might not be any subscribers so we
+        // need to ignore the error.
+        let _ = self.blocks.send(());
+    }
+
+    /// Subscribe to new contracts.
+    pub fn subscribe_contracts(&self) -> NewData {
+        NewData(self.contracts.subscribe())
+    }
+
+    /// Subscribe to new blocks.
+    pub fn subscribe_blocks(&self) -> NewData {
+        NewData(self.blocks.subscribe())
+    }
+}
+
+impl NewData {
+    /// Wait for new data.
+    /// Returns an error if the channel is closed.
+    pub async fn wait(&mut self) -> anyhow::Result<()> {
+        self.0
+            .changed()
+            .await
+            .map_err(|_| anyhow::anyhow!("channel closed"))
+    }
+}
+
+impl Default for Notify {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Default for StreamState {
+    fn default() -> Self {
+        StreamState {
+            state: State::Pos(Pos { page: 0, index: 0 }),
+            start: Start::default(),
+        }
+    }
+}

--- a/crates/storage/src/streams.rs
+++ b/crates/storage/src/streams.rs
@@ -52,10 +52,10 @@ struct Start {
 
 /// Get the next data in the stream.
 pub async fn next_data<F, Fut, D>(
-    get_data: F,
     mut new_data: NewData,
     state: StreamState,
     page_size: usize,
+    get_data: F,
 ) -> Option<(Vec<anyhow::Result<D>>, StreamState)>
 where
     F: Fn(GetData) -> Fut,

--- a/crates/storage/src/streams/tests.rs
+++ b/crates/storage/src/streams/tests.rs
@@ -1,0 +1,219 @@
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use super::*;
+
+#[tokio::test]
+async fn test_err() {
+    let notify = Notify::new();
+    let rx = notify.subscribe_contracts();
+    let (result, state) = next_data::<_, _, ()>(
+        |_| async { Err(anyhow::anyhow!("error")) },
+        rx.clone(),
+        StreamState::default(),
+        100,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert!(result[0].is_err());
+
+    let result = next_data::<_, _, ()>(
+        |_| async { Err(anyhow::anyhow!("error")) },
+        rx.clone(),
+        state.clone(),
+        100,
+    )
+    .await;
+    assert!(result.is_none());
+
+    let result =
+        next_data::<_, _, ()>(|_| async { Ok(vec![()]) }, rx.clone(), state.clone(), 100).await;
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn no_data() {
+    let notify = Notify::new();
+    let rx = notify.subscribe_contracts();
+    let num = Arc::new(AtomicUsize::new(0));
+    notify.notify_new_contracts();
+    let (result, state) = next_data::<_, _, ()>(
+        |_| async {
+            if num.fetch_add(1, Ordering::SeqCst) == 0 {
+                Ok(vec![])
+            } else {
+                Ok(vec![()])
+            }
+        },
+        rx.clone(),
+        StreamState::default(),
+        100,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert!(result[0].is_ok());
+    assert_eq!(num.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        state,
+        StreamState {
+            state: State::Pos(Pos { page: 0, index: 1 }),
+            start: Default::default()
+        }
+    );
+}
+
+#[tokio::test]
+async fn page_calc() {
+    let notify = Notify::new();
+    let rx = notify.subscribe_contracts();
+    let (result, state) = next_data::<_, _, ()>(
+        |_| async { Ok(vec![()]) },
+        rx.clone(),
+        StreamState::default(),
+        3,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert!(result[0].is_ok());
+    assert_eq!(
+        state,
+        StreamState {
+            state: State::Pos(Pos { page: 0, index: 1 }),
+            start: Default::default()
+        }
+    );
+
+    let (result, state) =
+        next_data::<_, _, ()>(|_| async { Ok(vec![(); 3]) }, rx.clone(), state, 3)
+            .await
+            .unwrap();
+
+    assert_eq!(result.len(), 2);
+    assert!(result.iter().all(|r| r.is_ok()));
+    assert_eq!(
+        state,
+        StreamState {
+            state: State::Pos(Pos { page: 1, index: 0 }),
+            start: Default::default()
+        }
+    );
+
+    let (result, state) =
+        next_data::<_, _, ()>(|_| async { Ok(vec![(); 3]) }, rx.clone(), state, 3)
+            .await
+            .unwrap();
+
+    assert_eq!(result.len(), 3);
+    assert!(result.iter().all(|r| r.is_ok()));
+    assert_eq!(
+        state,
+        StreamState {
+            state: State::Pos(Pos { page: 2, index: 0 }),
+            start: Default::default()
+        }
+    );
+
+    let (_, state) = next_data::<_, _, ()>(|_| async { Ok(vec![(); 2]) }, rx.clone(), state, 3)
+        .await
+        .unwrap();
+
+    let num = Arc::new(AtomicUsize::new(0));
+    notify.notify_new_contracts();
+    let (result, state) = next_data::<_, _, ()>(
+        |get| {
+            let num = num.clone();
+            async move {
+                assert_eq!(get.page, 2);
+                if num.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Ok(vec![(); 2])
+                } else {
+                    Ok(vec![(); 3])
+                }
+            }
+        },
+        rx.clone(),
+        state,
+        3,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert!(result.iter().all(|r| r.is_ok()));
+    assert_eq!(
+        state,
+        StreamState {
+            state: State::Pos(Pos { page: 3, index: 0 }),
+            start: Default::default()
+        }
+    );
+
+    let (_, state) = next_data::<_, _, ()>(|_| async { Ok(vec![(); 1]) }, rx.clone(), state, 3)
+        .await
+        .unwrap();
+
+    let num = Arc::new(AtomicUsize::new(0));
+    notify.notify_new_contracts();
+    let (result, state) = next_data::<_, _, ()>(
+        |get| {
+            let num = num.clone();
+            async move {
+                assert_eq!(get.page, 3);
+                if num.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Ok(vec![(); 1])
+                } else {
+                    Ok(vec![(); 2])
+                }
+            }
+        },
+        rx.clone(),
+        state,
+        3,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert!(result.iter().all(|r| r.is_ok()));
+    assert_eq!(
+        state,
+        StreamState {
+            state: State::Pos(Pos { page: 3, index: 2 }),
+            start: Default::default()
+        }
+    );
+}
+
+#[tokio::test]
+async fn ordering() {
+    let notify = Notify::new();
+    let rx = notify.subscribe_contracts();
+
+    let (result, state) = next_data::<_, _, _>(
+        |_| async { Ok(vec![1]) },
+        rx.clone(),
+        StreamState::default(),
+        3,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(*result[0].as_ref().unwrap(), 1);
+
+    let (result, _) = next_data::<_, _, _>(|_| async { Ok(vec![1, 2, 3]) }, rx.clone(), state, 3)
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 2);
+    assert_eq!(*result[0].as_ref().unwrap(), 2);
+    assert_eq!(*result[1].as_ref().unwrap(), 3);
+}

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -120,14 +120,14 @@ pub fn solution_with_all_inputs_fixed_size(i: usize, size: usize) -> Solution {
                     key: input.clone(),
                     value: input.clone()
                 };
-                i
+                size
             ],
             transient_data: vec![
                 Mutation {
                     key: input.clone(),
                     value: input.clone()
                 };
-                i
+                size
             ],
         }],
     }

--- a/crates/test_dbs/Cargo.toml
+++ b/crates/test_dbs/Cargo.toml
@@ -15,6 +15,7 @@ essential-rqlite-storage = { workspace = true }
 essential-sign = { workspace = true }
 essential-storage = { workspace = true }
 essential-types = { workspace = true }
+futures.workspace = true
 paste = { workspace = true }
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/test_dbs/tests/sanity.rs
+++ b/crates/test_dbs/tests/sanity.rs
@@ -137,7 +137,7 @@ async fn insert_solution_into_pool<S: Storage>(storage: S) {
         .unwrap();
     let solutions = storage.list_solutions_pool(None).await.unwrap();
     assert_eq!(solutions.len(), 0);
-    let batches = storage.list_blocks(None, None).await.unwrap();
+    let batches = storage.list_blocks(None, None, None).await.unwrap();
     assert_eq!(batches.len(), 1);
     assert_eq!(hash(&batches[0].solutions), hash(&vec![solution]));
 }

--- a/crates/test_dbs/tests/tests.rs
+++ b/crates/test_dbs/tests/tests.rs
@@ -147,7 +147,7 @@ async fn solutions<S: Storage>(storage: S) {
     assert_eq!(result.len(), 1);
     assert!(result.contains(&solution2));
 
-    let result = storage.list_blocks(None, None).await.unwrap();
+    let result = storage.list_blocks(None, None, None).await.unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].solutions, vec![solution.clone()]);
 
@@ -190,7 +190,7 @@ async fn solutions<S: Storage>(storage: S) {
     let result = storage.list_solutions_pool(None).await.unwrap();
     assert!(result.is_empty());
 
-    let result = storage.list_blocks(None, None).await.unwrap();
+    let result = storage.list_blocks(None, None, None).await.unwrap();
     assert_eq!(result.len(), 2);
     assert_eq!(result[0].solutions, vec![solution.clone()]);
     assert_eq!(


### PR DESCRIPTION
This adds server sent event apis for `/subscribe-contracts` and `/subscribe-blocks`. Internally it uses a stream unfold that does the initial `lists` and then awaits a watch channel for updates. I chose a watch instead of a notify because a watch `Receiver` will return from `changed()` if there has been any updates since the start of the channel. This means that the api will never miss an update. Compared to a notify which would work if we used `notify_one()` except that we can have multiple streams, so you would need to use `notify_waiters()` which only notifies streams actively awaiting the `notify` future. This makes it easy to miss an update.

The stream logic is abstracted across databases and contracts / blocks which makes it easier to maintain and test. It has to live in the `essential-storage` crate because of this though.

### TODO:
- [x] Add block number as a starting point for list-blocks and use it in subscribe blocks.
- [x] Add tests to value paging in mem storage
- [x] Add tests for subscription around different paging for db
- [x] Add rest server blocks integration tests
- [x] Add rest server contracts integration tests
- [x] Add rest server curl readme and tests