### PR TITLE
feature: add time to server

### DIFF
--- a/crates/rest-server/tests/integration.rs
+++ b/crates/rest-server/tests/integration.rs
@@ -263,7 +263,9 @@ async fn test_list_winning_blocks() {
 
     let mem = MemoryStorage::new();
     mem.insert_solution_into_pool(solution).await.unwrap();
-    mem.move_solutions_to_solved(&[hash]).await.unwrap();
+    mem.move_solutions_to_solved(0, Duration::from_secs(1), &[hash])
+        .await
+        .unwrap();
 
     let TestServer {
         client,
@@ -291,7 +293,9 @@ async fn test_solution_outcome() {
 
     let mem = MemoryStorage::new();
     mem.insert_solution_into_pool(solution).await.unwrap();
-    mem.move_solutions_to_solved(&[ca.0]).await.unwrap();
+    mem.move_solutions_to_solved(0, Duration::from_secs(1), &[ca.0])
+        .await
+        .unwrap();
 
     let TestServer {
         client,
@@ -425,7 +429,9 @@ async fn test_subscribe_blocks() {
             .await
             .unwrap();
     }
-    mem.move_solutions_to_solved(&hashes[0..1]).await.unwrap();
+    mem.move_solutions_to_solved(0, Duration::from_secs(1), &hashes[0..1])
+        .await
+        .unwrap();
 
     let TestServer {
         client,
@@ -447,7 +453,9 @@ async fn test_subscribe_blocks() {
     let r = tokio::time::timeout(Duration::from_millis(50), s.try_next()).await;
     assert!(r.is_err());
 
-    mem.move_solutions_to_solved(&hashes[1..3]).await.unwrap();
+    mem.move_solutions_to_solved(1, Duration::from_secs(2), &hashes[1..3])
+        .await
+        .unwrap();
 
     let block = s.try_next().await.unwrap().unwrap();
     assert_eq!(block.number, 1);
@@ -480,8 +488,10 @@ async fn test_subscribe_blocks() {
     let r = tokio::time::timeout(Duration::from_millis(50), s.try_next()).await;
     assert!(r.is_err());
 
-    for hash in &hashes[3..] {
-        mem.move_solutions_to_solved(&[*hash]).await.unwrap();
+    for (i, hash) in hashes[3..].iter().enumerate() {
+        mem.move_solutions_to_solved(i as u64 + 2, Duration::from_secs(i as u64 + 3), &[*hash])
+            .await
+            .unwrap();
     }
 
     let block = s.try_next().await.unwrap().unwrap();

--- a/crates/rest-server/tests/utils.rs
+++ b/crates/rest-server/tests/utils.rs
@@ -1,7 +1,10 @@
 #![allow(dead_code)]
 
+use std::sync::Arc;
+
 use essential_memory_storage::MemoryStorage;
 use essential_rest_server::run;
+use essential_server::TimeConfig;
 use reqwest::{Client, ClientBuilder};
 
 static SERVER: &str = "localhost:0";
@@ -23,7 +26,14 @@ pub async fn setup_with_mem(mem: MemoryStorage) -> TestServer {
     let (tx, rx) = tokio::sync::oneshot::channel();
     let (shutdown, shutdown_rx) = tokio::sync::oneshot::channel();
     let jh = tokio::task::spawn(async {
-        let essential = essential_server::Essential::new(mem, config);
+        let essential = essential_server::Essential::new(
+            mem,
+            config,
+            Arc::new(TimeConfig {
+                enable_time: false,
+                ..Default::default()
+            }),
+        );
         run(essential, SERVER, tx, Some(shutdown_rx), Default::default()).await
     });
     let client = ClientBuilder::new()

--- a/crates/rqlite-storage/sql/query/get_latest_block.sql
+++ b/crates/rqlite-storage/sql/query/get_latest_block.sql
@@ -1,0 +1,16 @@
+SELECT
+    batch_id,
+    solutions.solution,
+    batch.created_at_seconds,
+    batch.created_at_nanos
+FROM
+    solved
+    JOIN solutions ON solved.content_hash = solutions.content_hash
+    JOIN batch ON solved.batch_id = batch.id
+WHERE
+    batch_id IN (
+        SELECT
+            MAX(id)
+        FROM
+            batch
+    );

--- a/crates/rqlite-storage/src/lib.rs
+++ b/crates/rqlite-storage/src/lib.rs
@@ -721,8 +721,17 @@ fn move_solutions_to_failed(
         .collect())
 }
 
+/// Note that block_number is not actually used.
+/// It's not atomic to read the previous block number then increment it
+/// and use it in the next database write.
+///
+/// We could make the insert take the block number but it would introduce a lot
+/// of complexity and have potential to break if two servers are writing to the same database.
+/// We don't have a use case where multiple servers produces blocks so
+/// it could be ok to use the value that's passed in but this is probably better
+/// addressed in the block builder.
 fn move_solutions_to_solved(
-    block_number: u64,
+    _block_number: u64,
     block_timestamp: Duration,
     solutions: &[Hash],
 ) -> anyhow::Result<Vec<Vec<serde_json::Value>>> {

--- a/crates/rqlite-storage/src/lib.rs
+++ b/crates/rqlite-storage/src/lib.rs
@@ -389,13 +389,15 @@ impl Storage for RqliteStorage {
 
     async fn move_solutions_to_solved(
         &self,
+        block_number: u64,
+        block_timestamp: Duration,
         solutions: &[essential_types::Hash],
     ) -> anyhow::Result<()> {
         if solutions.is_empty() {
             return Ok(());
         }
 
-        let sql = move_solutions_to_solved(solutions)?;
+        let sql = move_solutions_to_solved(block_number, block_timestamp, solutions)?;
 
         // TODO: Is there a way to avoid this?
         // Maybe create an owned version of execute.
@@ -643,6 +645,8 @@ impl Storage for RqliteStorage {
             failed,
             solved,
             state_updates,
+            block_number,
+            block_timestamp,
         } = data;
         let r = if !failed.is_empty() {
             move_solutions_to_failed(failed)
@@ -654,7 +658,7 @@ impl Storage for RqliteStorage {
 
         let r = r.and_then(|mut sql| {
             let r = if !solved.is_empty() {
-                move_solutions_to_solved(solved)
+                move_solutions_to_solved(block_number, block_timestamp, solved)
             } else {
                 Ok(Vec::new())
             };
@@ -686,6 +690,12 @@ impl Storage for RqliteStorage {
             r
         }
     }
+
+    async fn get_latest_block(&self) -> anyhow::Result<Option<Block>> {
+        let sql = &[include_sql!("query/get_latest_block.sql")];
+        let queries = self.query_values(sql).await?;
+        values::get_latest_block(queries)
+    }
 }
 
 fn move_solutions_to_failed(
@@ -711,12 +721,14 @@ fn move_solutions_to_failed(
         .collect())
 }
 
-fn move_solutions_to_solved(solutions: &[Hash]) -> anyhow::Result<Vec<Vec<serde_json::Value>>> {
+fn move_solutions_to_solved(
+    block_number: u64,
+    block_timestamp: Duration,
+    solutions: &[Hash],
+) -> anyhow::Result<Vec<Vec<serde_json::Value>>> {
     if solutions.is_empty() {
         return Ok(Vec::new());
     }
-    let created_at = std::time::SystemTime::now();
-    let unix_time = created_at.duration_since(std::time::UNIX_EPOCH)?;
     let inserts = solutions.iter().flat_map(|hash| {
         let hash = encode(hash);
         [
@@ -726,8 +738,8 @@ fn move_solutions_to_solved(solutions: &[Hash]) -> anyhow::Result<Vec<Vec<serde_
     });
     let mut sql = vec![include_sql!(
         owned "insert/batch.sql",
-        unix_time.as_secs(),
-        unix_time.subsec_nanos()
+        block_timestamp.as_secs(),
+        block_timestamp.subsec_nanos()
     )];
     sql.extend(inserts);
     sql.push(include_sql!(owned "update/delete_empty_batch.sql"));

--- a/crates/rqlite-storage/tests/sql_solutions.rs
+++ b/crates/rqlite-storage/tests/sql_solutions.rs
@@ -594,6 +594,27 @@ fn test_batch_paging() {
             (43, "solution85".to_string(), 42 * 100, 42 * 100,),
         ]
     );
+
+    let result = query(
+        &conn,
+        include_sql!("query", "get_latest_block"),
+        [],
+        |row| {
+            (
+                row.get::<_, usize>(0).unwrap(),
+                row.get::<_, String>(1).unwrap(),
+                row.get::<_, usize>(2).unwrap(),
+                row.get::<_, usize>(3).unwrap(),
+            )
+        },
+    );
+    assert_eq!(
+        result,
+        vec![
+            (1000, "solution1998".to_string(), 99900, 99900),
+            (1000, "solution1999".to_string(), 99900, 99900),
+        ]
+    );
 }
 
 #[test]

--- a/crates/server/src/protocol.rs
+++ b/crates/server/src/protocol.rs
@@ -1,0 +1,67 @@
+use essential_types::{
+    contract::Contract,
+    predicate::Predicate,
+    solution::{Mutation, Solution, SolutionData},
+    ContentAddress, PredicateAddress,
+};
+
+/// # Storage
+/// l1_block_number
+/// { 0 => int }
+/// l1_block_timestamp
+/// { 1 => int }
+pub(crate) fn block_state_contract() -> Contract {
+    let predicates = vec![Predicate {
+        state_read: vec![],
+        constraints: vec![],
+        directive: essential_types::predicate::Directive::Satisfy,
+    }];
+
+    let salt = essential_hash::hash(&"block-state-contract");
+    Contract { predicates, salt }
+}
+
+pub(crate) fn block_state_contract_address() -> ContentAddress {
+    let contract = block_state_contract();
+    essential_hash::content_addr(&contract)
+}
+
+pub(crate) fn block_state_solution(l1_block_number: u64, l1_block_timestamp: u64) -> Solution {
+    let contract = block_state_contract();
+    let block_state_address = essential_hash::contract_addr::from_contract(&contract);
+    let predicate = essential_hash::content_addr(&contract.predicates[0]);
+    let predicate_to_solve = PredicateAddress {
+        contract: block_state_address,
+        predicate,
+    };
+    let l1_block_number = l1_block_number.try_into().unwrap();
+    let l1_block_timestamp = l1_block_timestamp.try_into().unwrap();
+    Solution {
+        data: vec![SolutionData {
+            predicate_to_solve,
+            decision_variables: Default::default(),
+            transient_data: Default::default(),
+            state_mutations: vec![
+                Mutation {
+                    key: vec![0],
+                    value: vec![l1_block_number],
+                },
+                Mutation {
+                    key: vec![1],
+                    value: vec![l1_block_timestamp],
+                },
+            ],
+        }],
+    }
+}
+
+#[test]
+#[ignore]
+fn print_time_address() {
+    let block_state_address = block_state_contract_address();
+    let words = essential_types::convert::word_4_from_u8_32(block_state_address.0);
+
+    println!("{:?}", block_state_address);
+    println!("{}", block_state_address);
+    println!("{:?}", words);
+}

--- a/crates/server/src/run.rs
+++ b/crates/server/src/run.rs
@@ -1,10 +1,12 @@
-use crate::{solution::read::read_contract_from_storage, PRUNE_FAILED_STORAGE_OLDER_THAN};
+use crate::{
+    solution::read::read_contract_from_storage, TimeConfig, PRUNE_FAILED_STORAGE_OLDER_THAN,
+};
 use anyhow::Context;
 use essential_hash::hash;
 use essential_state_read_vm::StateRead;
 use essential_storage::{failed_solution::SolutionFailReason, CommitData, Storage};
 use essential_transaction_storage::{Transaction, TransactionStorage};
-use essential_types::{solution::Solution, Hash};
+use essential_types::{contract::SignedContract, solution::Solution, Hash, Signature};
 use std::{sync::Arc, time::Duration};
 use tokio::sync::oneshot;
 
@@ -30,12 +32,18 @@ pub async fn run<S>(
     storage: &S,
     mut shutdown: Shutdown,
     run_loop_interval: Duration,
+    time_config: &TimeConfig,
 ) -> anyhow::Result<()>
 where
     S: Storage + StateRead + Clone + Send + Sync + 'static,
     <S as StateRead>::Future: Send,
     <S as StateRead>::Error: Send,
 {
+    if time_config.enable_time {
+        // Deploy the block state contract.
+        deploy_protocol_contracts(storage).await?;
+    }
+
     // Run the main loop on a fixed interval.
     // The interval is immediately ready the first time.
     let mut interval = tokio::time::interval(run_loop_interval);
@@ -48,22 +56,39 @@ where
         }
 
         // Errors are emitted via `tracing`.
-        let _ = run_loop(storage).await;
+        let _ = run_loop(storage, time_config).await;
     }
 }
 
+/// Deploy the protocol contracts.
+async fn deploy_protocol_contracts<S>(storage: &S) -> Result<(), anyhow::Error>
+where
+    S: Storage,
+{
+    let block_state_contract = crate::protocol::block_state_contract();
+
+    // Signing with fake signature because there's no
+    // private key to sign with and this is never checked
+    // at this level anyway.
+    let block_state_contract = SignedContract {
+        contract: block_state_contract,
+        signature: Signature([0; 64], 0),
+    };
+    storage.insert_contract(block_state_contract).await?;
+    Ok(())
+}
+
 #[cfg_attr(feature = "tracing", tracing::instrument(skip_all, err))]
-async fn run_loop<S>(storage: &S) -> anyhow::Result<()>
+async fn run_loop<S>(storage: &S, time_config: &TimeConfig) -> anyhow::Result<()>
 where
     S: Storage + StateRead + Clone + Send + Sync + 'static,
     <S as StateRead>::Future: Send,
     <S as StateRead>::Error: Send,
 {
     // Build a block.
-    let (solutions, transaction) = build_block(storage).await.context("error building block")?;
-
-    // FIXME: These 3 database commits should be atomic. If one fails they should all fail.
-    // We don't have transactions for storage yet so that will be required to implement this.
+    let (block_number, block_timestamp, solutions, transaction) = build_block(storage, time_config)
+        .await
+        .context("error building block")?;
 
     // Move failed solutions.
     let failed_solutions: Vec<(Hash, SolutionFailReason)> = solutions
@@ -80,6 +105,8 @@ where
         .collect();
 
     let data = CommitData {
+        block_number,
+        block_timestamp,
         failed: &failed_solutions,
         solved: &solved_solutions,
         state_updates: Box::new(transaction.into_updates()),
@@ -103,7 +130,10 @@ where
 ///
 /// The current implementation is very simple and just builds the
 /// block in FIFO order. If a solution becomes invalid, it is moved to failed.
-async fn build_block<S>(storage: &S) -> anyhow::Result<(Solutions, TransactionStorage<S>)>
+async fn build_block<S>(
+    storage: &S,
+    time_config: &TimeConfig,
+) -> anyhow::Result<(u64, Duration, Solutions, TransactionStorage<S>)>
 where
     S: Storage + StateRead + Clone + Send + Sync + 'static,
 {
@@ -116,6 +146,35 @@ where
 
     let mut valid_solutions: Vec<_> = vec![];
     let mut failed_solutions: Vec<_> = vec![];
+
+    let latest_block = storage.get_latest_block().await?;
+    let number = latest_block
+        .as_ref()
+        .map(|b| b.number.saturating_add(1))
+        .unwrap_or(0);
+    let timestamp = match &latest_block {
+        Some(block) => {
+            let monotonic_time = block.timestamp.saturating_add(Duration::from_secs(1));
+            let system_time = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or(monotonic_time);
+            monotonic_time.max(system_time)
+        }
+        None => std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default(),
+    };
+
+    let solutions = if time_config.enable_time {
+        // Add the block state solution at the begging of the block.
+        let block_state_solution =
+            crate::protocol::block_state_solution(number, timestamp.as_secs());
+        let mut s = vec![block_state_solution];
+        s.extend(solutions);
+        s
+    } else {
+        solutions
+    };
 
     for solution in solutions {
         #[cfg(feature = "tracing")]
@@ -152,7 +211,15 @@ where
         }
     }
 
+    // If there is only one valid solution then
+    // it's only the block state solution.
+    if valid_solutions.len() == 1 && time_config.enable_time {
+        valid_solutions.clear();
+    }
+
     Ok((
+        number,
+        timestamp,
         Solutions {
             valid_solutions,
             failed_solutions,

--- a/crates/server/src/run/tests.rs
+++ b/crates/server/src/run/tests.rs
@@ -21,7 +21,9 @@ where
     let (tx, rx) = tokio::sync::oneshot::channel();
     let shutdown = super::Shutdown(rx);
     let s = storage.clone();
-    let jh = tokio::spawn(async move { super::run(&s, shutdown, RUN_LOOP_FREQUENCY).await });
+    let jh = tokio::spawn(async move {
+        super::run(&s, shutdown, RUN_LOOP_FREQUENCY, &Default::default()).await
+    });
     tokio::time::sleep(Duration::from_millis(100)).await;
     tx.send(()).unwrap();
     jh.await?

--- a/crates/server/tests/tests.rs
+++ b/crates/server/tests/tests.rs
@@ -21,7 +21,7 @@ where
         predicate: predicate_address,
     };
 
-    let server = essential_server::Essential::new(s, Default::default());
+    let server = essential_server::Essential::new(s, Default::default(), Default::default());
     let config = essential_server::Config {
         run_loop_interval: Duration::from_millis(100),
     };

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -21,6 +21,10 @@ pub mod streams;
 /// Data to commit after a block has been built.
 /// This data should all be committed atomically.
 pub struct CommitData<'a> {
+    /// Block number
+    pub block_number: u64,
+    /// Block timestamp
+    pub block_timestamp: Duration,
     /// Failed solutions
     pub failed: &'a [(Hash, SolutionFailReason)],
     /// Solved solutions
@@ -48,6 +52,8 @@ pub trait Storage: StateStorage {
     /// Move these solutions from the pool to the solved state.
     fn move_solutions_to_solved(
         &self,
+        block_number: u64,
+        block_timestamp: Duration,
         solutions: &[Hash],
     ) -> impl Future<Output = anyhow::Result<()>> + Send;
 
@@ -124,6 +130,11 @@ pub trait Storage: StateStorage {
         &self,
         solution_hash: Hash,
     ) -> impl std::future::Future<Output = anyhow::Result<Option<SolutionOutcomes>>> + Send;
+
+    /// Get latest block.
+    fn get_latest_block(
+        &self,
+    ) -> impl std::future::Future<Output = anyhow::Result<Option<Block>>> + Send;
 
     /// Prune failed solutions that failed before the provided duration.
     fn prune_failed_solutions(

--- a/crates/test_dbs/tests/sanity.rs
+++ b/crates/test_dbs/tests/sanity.rs
@@ -132,7 +132,7 @@ async fn insert_solution_into_pool<S: Storage>(storage: S) {
     assert_eq!(solutions.len(), 1);
     assert_eq!(hash(&solutions[0].data), hash(&Solution::empty()));
     storage
-        .move_solutions_to_solved(&[hash(&Solution::empty())])
+        .move_solutions_to_solved(0, Default::default(), &[hash(&Solution::empty())])
         .await
         .unwrap();
     let solutions = storage.list_solutions_pool(None).await.unwrap();

--- a/crates/test_dbs/tests/storage.rs
+++ b/crates/test_dbs/tests/storage.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use essential_storage::{
     failed_solution::{CheckOutcome, FailedSolution, SolutionFailReason},
     CommitData, Storage,
@@ -124,7 +126,10 @@ async fn move_solutions_to_solved<S: Storage>(storage: S) {
     }
 
     // Move none
-    storage.move_solutions_to_solved(&[]).await.unwrap();
+    storage
+        .move_solutions_to_solved(0, Duration::from_secs(1), &[])
+        .await
+        .unwrap();
 
     let result = storage.list_solutions_pool(None).await.unwrap();
     assert_eq!(result.len(), 10);
@@ -135,7 +140,7 @@ async fn move_solutions_to_solved<S: Storage>(storage: S) {
 
     // Move some
     storage
-        .move_solutions_to_solved(&hashes[3..5])
+        .move_solutions_to_solved(0, Duration::from_secs(1), &hashes[3..5])
         .await
         .unwrap();
 
@@ -150,7 +155,10 @@ async fn move_solutions_to_solved<S: Storage>(storage: S) {
 
     // Move missing hash is noop
     let hash = essential_hash::hash(&solution_with_all_inputs(11));
-    storage.move_solutions_to_solved(&[hash]).await.unwrap();
+    storage
+        .move_solutions_to_solved(10, Duration::from_secs(10), &[hash])
+        .await
+        .unwrap();
 
     let result = storage.list_solutions_pool(None).await.unwrap();
     assert_eq!(result.len(), 8);
@@ -159,7 +167,7 @@ async fn move_solutions_to_solved<S: Storage>(storage: S) {
 
     // Move some with missing hash
     storage
-        .move_solutions_to_solved(&[hashes[9], hash])
+        .move_solutions_to_solved(1, Duration::from_secs(2), &[hashes[9], hash])
         .await
         .unwrap();
 
@@ -174,7 +182,10 @@ async fn move_solutions_to_solved<S: Storage>(storage: S) {
     assert_eq!(&result[1].solutions[..], &solutions[9..10]);
 
     // Move all
-    storage.move_solutions_to_solved(&hashes).await.unwrap();
+    storage
+        .move_solutions_to_solved(2, Duration::from_secs(3), &hashes)
+        .await
+        .unwrap();
     let result = storage.list_solutions_pool(None).await.unwrap();
     assert!(result.is_empty());
     let result = storage.list_blocks(None, None, None).await.unwrap();
@@ -186,7 +197,10 @@ async fn move_solutions_to_solved<S: Storage>(storage: S) {
     assert_eq!(&result[2].solutions[3..7], &solutions[5..9]);
 
     // Move all again is noop
-    storage.move_solutions_to_solved(&hashes).await.unwrap();
+    storage
+        .move_solutions_to_solved(3, Duration::from_secs(4), &hashes)
+        .await
+        .unwrap();
     let result = storage.list_solutions_pool(None).await.unwrap();
     assert!(result.is_empty());
     let result = storage.list_blocks(None, None, None).await.unwrap();
@@ -470,9 +484,13 @@ async fn list_blocks<S: Storage>(storage: S) {
             .unwrap();
     }
 
+    let time = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap();
+
     // Move one
     storage
-        .move_solutions_to_solved(&hashes[0..1])
+        .move_solutions_to_solved(0, time, &hashes[0..1])
         .await
         .unwrap();
 
@@ -485,7 +503,11 @@ async fn list_blocks<S: Storage>(storage: S) {
     // Move rest
     for i in 1..102 {
         storage
-            .move_solutions_to_solved(&hashes[i..i + 1])
+            .move_solutions_to_solved(
+                i as u64,
+                time + Duration::from_secs(i as u64 + 1),
+                &hashes[i..i + 1],
+            )
             .await
             .unwrap();
     }
@@ -567,11 +589,8 @@ async fn list_blocks<S: Storage>(storage: S) {
     assert_eq!(result.len(), 0);
 
     // List within time
-    let time = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap();
-    let start = time - std::time::Duration::from_secs(100);
-    let end = time + std::time::Duration::from_secs(100);
+    let start = time - std::time::Duration::from_secs(200);
+    let end = time + std::time::Duration::from_secs(200);
 
     let result = storage
         .list_blocks(Some(start..end), None, None)
@@ -654,7 +673,7 @@ async fn get_solution<S: Storage>(storage: S) {
     }
 
     storage
-        .move_solutions_to_solved(&hashes[1..2])
+        .move_solutions_to_solved(0, Duration::from_secs(1), &hashes[1..2])
         .await
         .unwrap();
     storage
@@ -700,7 +719,7 @@ async fn get_solution<S: Storage>(storage: S) {
     }
 
     storage
-        .move_solutions_to_solved(&hashes[2..3])
+        .move_solutions_to_solved(1, Duration::from_secs(2), &hashes[2..3])
         .await
         .unwrap();
     storage
@@ -718,7 +737,7 @@ async fn get_solution<S: Storage>(storage: S) {
     }
 
     storage
-        .move_solutions_to_solved(&hashes[1..2])
+        .move_solutions_to_solved(2, Duration::from_secs(3), &hashes[1..2])
         .await
         .unwrap();
     storage
@@ -731,24 +750,25 @@ async fn get_solution<S: Storage>(storage: S) {
 
     // Get existing solution in solved
     let result = storage.get_solution(hashes[1]).await.unwrap().unwrap();
+    eprintln!("{:?}", result);
     assert_eq!(result.solution, solutions[1]);
     assert_eq!(result.outcome.len(), 3);
     assert_eq!(result.outcome[0], CheckOutcome::Success(0));
+    assert_eq!(result.outcome[1], CheckOutcome::Success(2));
     assert_eq!(
-        result.outcome[1],
+        result.outcome[2],
         CheckOutcome::Fail(SolutionFailReason::NotComposable)
     );
-    assert_eq!(result.outcome[2], CheckOutcome::Success(2));
 
     // Get existing solution in failed
     let result = storage.get_solution(hashes[2]).await.unwrap().unwrap();
     assert_eq!(result.solution, solutions[2]);
     assert_eq!(result.outcome.len(), 3);
+    assert_eq!(result.outcome[0], CheckOutcome::Success(1));
     assert_eq!(
-        result.outcome[0],
+        result.outcome[1],
         CheckOutcome::Fail(SolutionFailReason::NotComposable)
     );
-    assert_eq!(result.outcome[1], CheckOutcome::Success(1));
     assert_eq!(
         result.outcome[2],
         CheckOutcome::Fail(SolutionFailReason::NotComposable)
@@ -821,6 +841,8 @@ async fn commit_block<S: Storage>(storage: S) {
         failed: &failed,
         solved: &solved,
         state_updates: Box::new(state_updates),
+        block_number: 0,
+        block_timestamp: Duration::from_secs(1),
     };
     storage.commit_block(data).await.unwrap();
 

--- a/crates/test_dbs/tests/tests.rs
+++ b/crates/test_dbs/tests/tests.rs
@@ -140,7 +140,7 @@ async fn solutions<S: Storage>(storage: S) {
     assert!(result.contains(&solution2));
 
     storage
-        .move_solutions_to_solved(&[hash(&solution)])
+        .move_solutions_to_solved(0, Duration::from_secs(0), &[hash(&solution)])
         .await
         .unwrap();
 
@@ -163,7 +163,11 @@ async fn solutions<S: Storage>(storage: S) {
         .unwrap();
 
     storage
-        .move_solutions_to_solved(&[hash(&solution2), hash(&solution3)])
+        .move_solutions_to_solved(
+            1,
+            Duration::from_secs(1),
+            &[hash(&solution2), hash(&solution3)],
+        )
         .await
         .unwrap();
 
@@ -216,6 +220,9 @@ async fn solutions<S: Storage>(storage: S) {
 create_test!(subscribe_blocks);
 
 async fn subscribe_blocks<S: Storage + Clone + Send + Sync + 'static>(storage: S) {
+    let time = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap();
     let solutions: Vec<_> = (0..102)
         .map(|i| solution_with_all_inputs_fixed_size(i, 1))
         .collect();
@@ -234,8 +241,13 @@ async fn subscribe_blocks<S: Storage + Clone + Send + Sync + 'static>(storage: S
     let jh = tokio::spawn({
         let storage = storage.clone();
         async move {
+            let mut i = 0;
             while let Some(hashes) = rx.recv().await {
-                storage.move_solutions_to_solved(&hashes).await.unwrap();
+                storage
+                    .move_solutions_to_solved(i, time + Duration::from_secs(i), &hashes)
+                    .await
+                    .unwrap();
+                i += 1;
             }
         }
     });
@@ -326,9 +338,6 @@ async fn subscribe_blocks<S: Storage + Clone + Send + Sync + 'static>(storage: S
         .unwrap();
     assert!(results.is_empty());
 
-    let time = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap();
     let start = time - std::time::Duration::from_secs(100);
 
     // List within start time
@@ -371,7 +380,7 @@ async fn subscribe_blocks<S: Storage + Clone + Send + Sync + 'static>(storage: S
     assert_eq!(results[0].solutions[0], solutions[101]);
 
     // List outside time
-    let start = start + std::time::Duration::from_secs(200);
+    let start = start + std::time::Duration::from_secs(2000);
     let results: Vec<_> = storage
         .clone()
         .subscribe_blocks(Some(start), None, None)
@@ -449,7 +458,10 @@ async fn double_get_solution_bug<S: Storage>(storage: S) {
     let result = storage.list_solutions_pool(None).await.unwrap();
     assert_eq!(result.len(), 1);
 
-    storage.move_solutions_to_solved(&[hash]).await.unwrap();
+    storage
+        .move_solutions_to_solved(0, Duration::from_secs(1), &[hash])
+        .await
+        .unwrap();
 
     let result = storage.get_solution(hash).await.unwrap().unwrap();
     assert_eq!(result.outcome, vec![CheckOutcome::Success(0)]);
@@ -473,7 +485,10 @@ async fn double_get_solution_bug<S: Storage>(storage: S) {
     let result = storage.get_solution(hash).await.unwrap().unwrap();
     assert_eq!(result.outcome, vec![CheckOutcome::Success(0)]);
 
-    storage.move_solutions_to_solved(&[hash]).await.unwrap();
+    storage
+        .move_solutions_to_solved(1, Duration::from_secs(2), &[hash])
+        .await
+        .unwrap();
 
     let result = storage.get_solution(hash).await.unwrap().unwrap();
     assert_eq!(
@@ -504,7 +519,10 @@ async fn list_solutions_pool_order<S: Storage>(storage: S) {
     let result = storage.list_solutions_pool(None).await.unwrap();
     assert_eq!(result, solutions);
 
-    storage.move_solutions_to_solved(&hashes).await.unwrap();
+    storage
+        .move_solutions_to_solved(0, Duration::from_secs(1), &hashes)
+        .await
+        .unwrap();
 
     for solution in solutions.iter().rev() {
         storage


### PR DESCRIPTION
Adds a contract that contains the current block time and number. This is always set at the start of the block and the server will ignore any solutions that try to solve this contract so that only the server solves it.