### PR TITLE
Fix typos

### DIFF
--- a/crates/rest-server/README.md
+++ b/crates/rest-server/README.md
@@ -209,7 +209,7 @@ curl --http2-prior-knowledge -X POST -H "Content-Type: application/json" -d '{"s
 ### Post `/query-state-reads`
 Run a query on state using state read programs,\
 This allows you to use the state read parts of your pint program to query state.\
-This is also useful for getting the pre state for a solution when debugging.\
+This is also useful for getting the pre-state for a solution when debugging.\
 Body: `QueryStateReads` as JSON \
 ```rust
 pub struct QueryStateReads {

--- a/crates/test_dbs/tests/tests.rs
+++ b/crates/test_dbs/tests/tests.rs
@@ -403,7 +403,7 @@ async fn update_and_query_state<S: Storage>(storage: S) {
     let key = vec![0; 4];
     let word = vec![42];
 
-    // Test updating the state without an contract
+    // Test updating the state without a contract
     storage
         .update_state(&address, &key, word.clone())
         .await


### PR DESCRIPTION
- Corrected "pre state" to "pre-state" in `README.md`.
- Fixed the word "contract" in `tests.rs` to correct its usage.
